### PR TITLE
Manage and approve employee work hours

### DIFF
--- a/src/pages/WorkHours.jsx
+++ b/src/pages/WorkHours.jsx
@@ -737,6 +737,13 @@ export default function WorkHours() {
               paidStatus={paidStatus}
               siteOptions={siteOptions}
               showPaymentControl={isAdmin}
+              onChange={handleChange}
+              readOnly={(empId) => {
+                if (isAdmin) return true; // admin cannot edit inputs
+                if (isUser) return true;  // user is read-only
+                // manager can edit unless this week is marked paid for that employee
+                return paidStatus[`${currentWeekLabel}_${empId}`] === true;
+              }}
               onPaymentToggle={(key, newStatus) => {
                 setPaidStatus(prev => ({
                   ...prev,
@@ -764,6 +771,12 @@ export default function WorkHours() {
                     siteOptions={[site]}
                     siteScope={site === '(Pa site)' ? '' : site}
                     showPaymentControl={isAdmin}
+                    onChange={handleChange}
+                    readOnly={(empId) => {
+                      if (isAdmin) return true;
+                      if (isUser) return true;
+                      return paidStatus[`${currentWeekLabel}_${empId}`] === true;
+                    }}
                     onPaymentToggle={(key, newStatus) => {
                       setPaidStatus(prev => ({
                         ...prev,


### PR DESCRIPTION
Implement role-based work hour management, allowing managers to edit unpaid hours and sites, and admins to mark weeks as paid.

This PR enables managers to add and edit work hours and sites for their assigned employees (and themselves) for any week not yet marked as paid. Once an admin marks a week as paid, it becomes read-only for managers. Regular users can only view their own hours in read-only mode, and admins can control payment status but cannot edit hour entries.

---
<a href="https://cursor.com/background-agent?bcId=bc-35e9a344-4f96-4ae0-89a8-6dd7e8517f7a">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-35e9a344-4f96-4ae0-89a8-6dd7e8517f7a">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

