### PR TITLE
Fix work hours jsx syntax error

### DIFF
--- a/src/pages/WorkHours.jsx
+++ b/src/pages/WorkHours.jsx
@@ -868,5 +868,6 @@ export default function WorkHours() {
           </div>
         )}
         </div>
-      
+      </div>
+    </div>
   );


### PR DESCRIPTION
Add missing closing `</div>` tags to `WorkHours.jsx` to resolve a build error.

The build failed with an "Unexpected end of file before a closing 'div' tag" error because the `WorkHours.jsx` component was missing three `</div>` tags at the end of the file, leading to an unbalanced HTML structure.

---
<a href="https://cursor.com/background-agent?bcId=bc-bc99aa86-14a4-4593-b500-45f58fc1494d">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-bc99aa86-14a4-4593-b500-45f58fc1494d">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

