### PR TITLE
Fix mobile menu open/close bug

### DIFF
--- a/src/components/ui/Layout.jsx
+++ b/src/components/ui/Layout.jsx
@@ -134,14 +134,14 @@ export function MobileSidebar({ isOpen, onClose, children }) {
       {/* Overlay */}
       {isOpen && (
         <div 
-          className="fixed inset-0 bg-black bg-opacity-50 z-40 lg:hidden backdrop-blur-sm"
+          className="fixed inset-0 bg-black bg-opacity-50 z-[60] lg:hidden backdrop-blur-sm"
           onClick={onClose}
         />
       )}
       
       {/* Sidebar */}
       <div className={`
-        fixed inset-y-0 left-0 z-50 w-80 sm:w-96 transform transition-all duration-300 ease-in-out lg:hidden
+        fixed inset-y-0 left-0 z-[70] w-80 sm:w-96 transform transition-all duration-300 ease-in-out lg:hidden
         ${isOpen ? 'translate-x-0' : '-translate-x-full'}
       `}>
         {children}

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -731,8 +731,9 @@ p {
   top: 0;
   z-index: 50;
 }
-  
-  /* Ensure mobile sidebar is completely hidden on desktop */
+
+/* Ensure mobile sidebar is completely hidden on desktop */
+@media (min-width: 1024px) {
   .mobile-sidebar-overlay {
     display: none !important;
   }
@@ -740,6 +741,7 @@ p {
   .mobile-sidebar {
     display: none !important;
   }
+}
   
   /* Ensure content doesn't overflow when sidebar is open */
   .main-content-constrained {


### PR DESCRIPTION
Adjust mobile sidebar visibility and z-index to fix the issue where the menu was not opening or closing on mobile.

The mobile sidebar was previously forced hidden on all screen sizes by global CSS rules, and its z-index was too low, causing it to be obscured by the sticky header. This PR ensures the sidebar is only hidden on desktop and renders above the header on mobile.

---
<a href="https://cursor.com/background-agent?bcId=bc-93da7239-bb5f-4c07-b663-9eaacadeb609">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-93da7239-bb5f-4c07-b663-9eaacadeb609">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

